### PR TITLE
refactor: handle concurrent calls to DB

### DIFF
--- a/api/src/main/kotlin/http/domain/BuildingSite.kt
+++ b/api/src/main/kotlin/http/domain/BuildingSite.kt
@@ -17,7 +17,7 @@ data class BuildingSite(
             id = this.id.toString(),
             buildingLimits = mapper.writeValueAsString(this.buildingLimits),
             heightPlateaus = mapper.writeValueAsString(this.heightPlateaus),
-            splitBuildingLimits = mapper.writeValueAsString(this.splitBuildingLimits),
+            splitBuildingLimits = mapper.writeValueAsString(this.splitBuildingLimits)
         )
     }
 }

--- a/persistence/src/main/kotlin/model/BuildingSites.kt
+++ b/persistence/src/main/kotlin/model/BuildingSites.kt
@@ -3,12 +3,15 @@ package com.weronka.golonka.model
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbBean
 import software.amazon.awssdk.enhanced.dynamodb.mapper.annotations.DynamoDbPartitionKey
 import java.util.UUID
+import software.amazon.awssdk.enhanced.dynamodb.extensions.annotations.DynamoDbVersionAttribute
 
 @DynamoDbBean
-class BuildingSites(
+data class BuildingSites(
     @get:DynamoDbPartitionKey
     var id: String = UUID.randomUUID().toString(),
     var buildingLimits: String = "",
     var heightPlateaus: String = "",
-    var splitBuildingLimits: String = ""
+    var splitBuildingLimits: String = "",
+    @get:DynamoDbVersionAttribute
+    var version: Long? = null
 )

--- a/persistence/src/test/kotlin/repository/BuildingSitesRepositoryTest.kt
+++ b/persistence/src/test/kotlin/repository/BuildingSitesRepositoryTest.kt
@@ -103,11 +103,26 @@ class BuildingSitesRepositoryTest :
                     splitBuildingLimits = testBuildingSite.splitBuildingLimits,
                 )
 
-            it("should return updated Building Site object on successful update") {
+            it("should update version id") {
+                repository.createBuildingSite(testBuildingSite)
                 val result = repository.updateBuildingSite(newBuildingSite)
 
+                result.version shouldBe 2
+            }
+
+            it("should return updated Building Site object on successful update") {
+                repository.createBuildingSite(testBuildingSite)
+                val result = repository.updateBuildingSite(newBuildingSite)
+
+                dynamoDbProvider.geBuildingSitesTable().scan().items().toList().size shouldBe 1
                 result.id shouldBe newBuildingSite.id
                 result.heightPlateaus shouldBe newBuildingSite.heightPlateaus
+            }
+
+            it("should throw BuildingSiteDoesNotExistsException when updating Building Site that doesn't exist") {
+                shouldThrow<BuildingSiteDoesNotExistsException> {
+                    repository.updateBuildingSite(testBuildingSite)
+                }
             }
         }
 


### PR DESCRIPTION
- added `version` attribute to `BuildingSites` DynamodDb DTO to enable optimistic locking