### PR TITLE
refactor: rename POST endpoint

### DIFF
--- a/api/src/main/kotlin/http/routes/SplitBuildingLimitsRoute.kt
+++ b/api/src/main/kotlin/http/routes/SplitBuildingLimitsRoute.kt
@@ -114,8 +114,8 @@ fun splitBuildingWithLimitsRoute(
                 splitBuildingLimits = exampleSplit,
             )
 
-    return "/split" meta {
-        summary = "Divides building limits according to provided height plateaus"
+    return "/building-sites" meta {
+        summary = "Creates Building Sites with divided building limits according to provided height plateaus"
         receiving(exampleBody)
         returning(Status.CREATED, exampleResponse)
     } bindContract Method.POST to { req: Request ->

--- a/api/src/test/kotlin/http/routes/SplitBuildingLimitsRouteKtTest.kt
+++ b/api/src/test/kotlin/http/routes/SplitBuildingLimitsRouteKtTest.kt
@@ -41,7 +41,7 @@ class SplitBuildingLimitsRouteKtTest :
         it("should return http 201 on successful division") {
             val response =
                 handler(
-                    Request(Method.POST, "http://test-url/split").with(
+                    Request(Method.POST, "http://test-url/building-sites").with(
                         SplitBuildingLimitsRequest.lens of
                             SplitBuildingLimitsRequest(
                                 buildingLimits = FeatureCollection(),
@@ -56,7 +56,7 @@ class SplitBuildingLimitsRouteKtTest :
         it("should return http 400 if body request is invalid") {
             val response =
                 handler(
-                    Request(Method.POST, "http://test-url/split").body("Invalid body"),
+                    Request(Method.POST, "http://test-url/building-sites").body("Invalid body"),
                 )
 
             response.status shouldBe Status.BAD_REQUEST

--- a/end-to-end-tests/src/main.py
+++ b/end-to-end-tests/src/main.py
@@ -13,7 +13,7 @@ def main():
 
     API_STAGE="local"
     REST_API_ID=apis['items'][0]['id']
-    URL=f"{ENDPOINT_URL}/restapis/{REST_API_ID}/{API_STAGE}/_user_request_/split"
+    URL=f"{ENDPOINT_URL}/restapis/{REST_API_ID}/{API_STAGE}/_user_request_/building-sites"
 
     suite=unittest.TestSuite([
         PolyBuildAPITestCases(URL, "test_valid_request"),

--- a/local/local-aws/init.sh
+++ b/local/local-aws/init.sh
@@ -54,11 +54,11 @@ REST_API_ID=$(awslocal apigateway create-rest-api --name poly-build-api-gateway 
 ROOT_ID=$(awslocal apigateway get-resources --rest-api-id "$REST_API_ID" --query "items[?path=='/'].id" --output text)
 
 # POST ENDPOINT
-echo "EXPOSE SPLIT ENDPOINT"
+echo "EXPOSE BUILDING_SITES ENDPOINT"
 SPLIT_ENDPOINT_RESOURCE_ID=$(awslocal apigateway create-resource \
     --rest-api-id $REST_API_ID \
     --parent-id $ROOT_ID \
-    --path-part "split" | jq -r '.id')
+    --path-part "building-sites" | jq -r '.id')
 
 awslocal apigateway put-method \
     --rest-api-id $REST_API_ID \


### PR DESCRIPTION
- renamed the endpoint from `/split` to `/building-sites` to comply with REST convention